### PR TITLE
Implemented search for db file

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Delver Lens Extract</title>
+</head>
+<body>
+    <div id="root"></div>
+</body>
+</html>


### PR DESCRIPTION
In the new APK, the database file resides in `res/Cc.db` - since there might be different revision with different filenames for the database, I added a search for the database file and also adjusted the errors regarding the database to additionally use `alert` which gives an output for non-tech-savvy users. 

The `index.html` file is also needed for the project to start up when using `npm start`, therefore it should be included (imho). 

Just did this since I wanted to thank you for saving me some (probably hours of) time on how to use the `dlens` file.